### PR TITLE
Implement GitHub repo import and parse imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250525.0",
+        "@types/node": "^20.11.30",
         "prettier": "^3.5.3",
         "typescript": "^5.8.3",
         "wrangler": "^4.16.1"
@@ -1609,6 +1610,16 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.17.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
+      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -4482,6 +4493,13 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.17",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250525.0",
+    "@types/node": "^20.11.30",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
     "wrangler": "^4.16.1"

--- a/src/user-graph.ts
+++ b/src/user-graph.ts
@@ -1,7 +1,13 @@
+import { Octokit } from 'octokit'
+import * as ts from 'typescript'
+import { Buffer } from 'buffer'
+import * as path from 'path'
+
 export class UserGraph {
   state: DurableObjectState
   env: Env
   kuzu: any | null = null
+  conn: any | null = null
 
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
@@ -11,28 +17,167 @@ export class UserGraph {
   async ensureDB() {
     if (this.kuzu) return;
     const { default: kuzu } = await import('kuzu');
-    const dbPath = await this.state.storage.get<string>('dbPath');
+    let dbPath = await this.state.storage.get<string>('dbPath');
     if (!dbPath) {
-      // create a new db within durable object storage
-      const path = `/tmp/${this.state.id.toString()}.kuzu`; // ephemeral path
-      this.kuzu = new kuzu.Database(path);
-      await this.state.storage.put('dbPath', path);
+      dbPath = `/tmp/${this.state.id.toString()}.kuzu`;
+      this.kuzu = new kuzu.Database(dbPath);
+      this.conn = new kuzu.Connection(this.kuzu);
+      await this.conn.init();
+      await this.initSchema();
+      await this.state.storage.put('dbPath', dbPath);
     } else {
       this.kuzu = new kuzu.Database(dbPath);
+      this.conn = new kuzu.Connection(this.kuzu);
+      await this.conn.init();
     }
+  }
+
+  async initSchema() {
+    await this.conn!.query(
+      'CREATE NODE TABLE IF NOT EXISTS File(path STRING, PRIMARY KEY(path));',
+    );
+    await this.conn!.query(
+      'CREATE NODE TABLE IF NOT EXISTS Class(name STRING, PRIMARY KEY(name));',
+    );
+    await this.conn!.query(
+      'CREATE NODE TABLE IF NOT EXISTS Function(name STRING, PRIMARY KEY(name));',
+    );
+    await this.conn!.query(
+      'CREATE NODE TABLE IF NOT EXISTS Variable(name STRING, PRIMARY KEY(name));',
+    );
+    await this.conn!.query(
+      'CREATE REL TABLE IF NOT EXISTS FileDeclaresClass(FROM File TO Class);',
+    );
+    await this.conn!.query(
+      'CREATE REL TABLE IF NOT EXISTS FileDeclaresFunction(FROM File TO Function);',
+    );
+    await this.conn!.query(
+      'CREATE REL TABLE IF NOT EXISTS FileDeclaresVariable(FROM File TO Variable);',
+    );
+    await this.conn!.query(
+      'CREATE REL TABLE IF NOT EXISTS FileImportsClass(FROM File TO Class);',
+    );
+    await this.conn!.query(
+      'CREATE REL TABLE IF NOT EXISTS FileImportsFunction(FROM File TO Function);',
+    );
+    await this.conn!.query(
+      'CREATE REL TABLE IF NOT EXISTS FileImportsVariable(FROM File TO Variable);',
+    );
+  }
+
+  parseFile(src: string) {
+    const sf = ts.createSourceFile('tmp.ts', src, ts.ScriptTarget.Latest, true);
+    const classes: string[] = [];
+    const functions: string[] = [];
+    const variables: string[] = [];
+    const imports: { name: string; from: string }[] = [];
+    const visit = (node: ts.Node) => {
+      if (ts.isClassDeclaration(node) && node.name) {
+        classes.push(node.name.text);
+      }
+      if (ts.isFunctionDeclaration(node) && node.name) {
+        functions.push(node.name.text);
+      }
+      if (ts.isVariableStatement(node)) {
+        for (const d of node.declarationList.declarations) {
+          if (ts.isIdentifier(d.name)) variables.push(d.name.text);
+        }
+      }
+      if (ts.isImportDeclaration(node)) {
+        const mod = (node.moduleSpecifier as ts.StringLiteral).text;
+        if (node.importClause) {
+          if (node.importClause.name) {
+            imports.push({ name: node.importClause.name.text, from: mod });
+          }
+          const named = node.importClause.namedBindings;
+          if (named) {
+            if (ts.isNamespaceImport(named)) {
+              imports.push({ name: named.name.text + '.*', from: mod });
+            } else if (ts.isNamedImports(named)) {
+              for (const el of named.elements) {
+                imports.push({ name: el.name.text, from: mod });
+              }
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(sf, visit);
+    return { classes, functions, variables, imports };
   }
 
   async loadRepo(token: string, repo: string) {
     await this.ensureDB();
-    // placeholder: just store repo info
+    const octokit = new Octokit({ auth: token });
+    const [owner, name] = repo.split('/');
+
+    const treeRes = await octokit.rest.git.getTree({
+      owner,
+      repo: name,
+      tree_sha: 'HEAD',
+      recursive: 'true',
+    });
+
+    const files = treeRes.data.tree.filter(
+      (t: any) => t.type === 'blob' && (t.path.endsWith('.ts') || t.path.endsWith('.tsx')),
+    );
+
+    const parsed: Record<string, { classes: string[]; functions: string[]; variables: string[]; imports: { name: string; from: string }[] }> = {};
+
+    for (const file of files) {
+      const blob = await octokit.rest.git.getBlob({ owner, repo: name, file_sha: file.sha });
+      const content = Buffer.from(blob.data.content, 'base64').toString();
+      parsed[file.path] = this.parseFile(content);
+    }
+
+    for (const [fp, data] of Object.entries(parsed)) {
+      const filePath = fp.replace(/'/g, "''");
+      await this.conn!.query(`CREATE (:File {path: '${filePath}'});`);
+      for (const cls of data.classes) {
+        const clsEsc = cls.replace(/'/g, "''");
+        await this.conn!.query(
+          `MATCH(f:File {path:'${filePath}'}) CREATE (f)-[:FileDeclaresClass]->(:Class {name:'${clsEsc}'});`,
+        );
+      }
+      for (const fn of data.functions) {
+        const fnEsc = fn.replace(/'/g, "''");
+        await this.conn!.query(
+          `MATCH(f:File {path:'${filePath}'}) CREATE (f)-[:FileDeclaresFunction]->(:Function {name:'${fnEsc}'});`,
+        );
+      }
+      for (const v of data.variables) {
+        const vEsc = v.replace(/'/g, "''");
+        await this.conn!.query(
+          `MATCH(f:File {path:'${filePath}'}) CREATE (f)-[:FileDeclaresVariable]->(:Variable {name:'${vEsc}'});`,
+        );
+      }
+    }
+
+    for (const [fp, data] of Object.entries(parsed)) {
+      const filePath = fp.replace(/'/g, "''");
+      for (const im of data.imports) {
+        const nameEsc = im.name.replace(/'/g, "''");
+        await this.conn!.query(
+          `MATCH(f:File {path:'${filePath}'}), (c:Class {name:'${nameEsc}'}) CREATE (f)-[:FileImportsClass]->(c);`,
+        );
+        await this.conn!.query(
+          `MATCH(f:File {path:'${filePath}'}), (fn:Function {name:'${nameEsc}'}) CREATE (f)-[:FileImportsFunction]->(fn);`,
+        );
+        await this.conn!.query(
+          `MATCH(f:File {path:'${filePath}'}), (v:Variable {name:'${nameEsc}'}) CREATE (f)-[:FileImportsVariable]->(v);`,
+        );
+      }
+    }
+
     await this.state.storage.put('repo', { token, repo });
   }
 
   async query(cypher: string) {
     await this.ensureDB();
-    // placeholder query execution
-    const result = this.kuzu.query(cypher);
-    return result.toArray();
+    const result = await this.conn!.query(cypher);
+    const r = Array.isArray(result) ? result[0] : result;
+    return r.getAll();
   }
 
   async fetch(request: Request) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         /* Specify how TypeScript looks up a file from a given module specifier. */
         "moduleResolution": "bundler",
         /* Specify type package names to be included without being referenced in a source file. */
-        "types": ["@cloudflare/workers-types/2023-07-01"],
+        "types": ["@cloudflare/workers-types/2023-07-01", "node"],
         /* Enable importing .json files */
         "resolveJsonModule": true,
 


### PR DESCRIPTION
## Summary
- extend graph schema for variables and import relationships
- parse variable declarations and import statements
- store imports as edges during repo load

## Testing
- `npm install`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6841216b532083229303a2267d4af1cb